### PR TITLE
Fix play button not properly pausing.

### DIFF
--- a/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/PlaybackControllerActivity.java
+++ b/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/PlaybackControllerActivity.java
@@ -171,9 +171,14 @@ public class PlaybackControllerActivity extends AppCompatActivity {
             MediaControllerCompat.TransportControls controls = controller.getTransportControls();
 
             if (isPlaying) {
-                controls.pause();
+                if (controller.getPlaybackState().getState() == PlaybackStateCompat.STATE_PLAYING) {
+                    controls.pause();
+                } else if (controller.getPlaybackState().getState() == PlaybackStateCompat.STATE_PAUSED) {
+                    controls.play();
+                }
             } else {
                 controls.playFromMediaId(item.getMediaId(), null);
+                mCurrentMediaId = item.getMediaId();
             }
         }
     }

--- a/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/PlaybackControllerActivity.java
+++ b/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/PlaybackControllerActivity.java
@@ -165,12 +165,12 @@ public class PlaybackControllerActivity extends AppCompatActivity {
         }
     }
 
-    protected void onMediaItemSelected(MediaBrowserCompat.MediaItem item, boolean isPlaying) {
+    protected void onMediaItemSelected(MediaBrowserCompat.MediaItem item, boolean isSameMedia) {
         if (item.isPlayable()) {
             MediaControllerCompat controller = MediaControllerCompat.getMediaController(this);
             MediaControllerCompat.TransportControls controls = controller.getTransportControls();
 
-            if (isPlaying) {
+            if (isSameMedia) {
                 if (controller.getPlaybackState().getState() == PlaybackStateCompat.STATE_PLAYING) {
                     controls.pause();
                 } else if (controller.getPlaybackState().getState() == PlaybackStateCompat.STATE_PAUSED) {

--- a/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/mediaui/FullscreenPlayerFragment.java
+++ b/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/mediaui/FullscreenPlayerFragment.java
@@ -1,0 +1,10 @@
+package com.koalatea.thehollidayinn.softwareengineeringdaily.mediaui;
+
+import android.app.Fragment;
+
+/**
+ * Created by George Lin on 10/19/2017.
+ */
+
+public class FullscreenPlayerFragment extends Fragment{
+}

--- a/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/podcast/PodcastDetailActivity.java
+++ b/app/src/main/java/com/koalatea/thehollidayinn/softwareengineeringdaily/podcast/PodcastDetailActivity.java
@@ -328,7 +328,7 @@ public class PodcastDetailActivity extends PlaybackControllerActivity {
         new MediaBrowserCompat.MediaItem(item.getDescription(),
           MediaBrowserCompat.MediaItem.FLAG_PLAYABLE);
 
-      boolean isPlaying = id.equals(getPlayingMediaId());
-      onMediaItemSelected(bItem, isPlaying);
+      boolean isSameMedia = id.equals(getPlayingMediaId());
+      onMediaItemSelected(bItem, isSameMedia);
     }
 }


### PR DESCRIPTION
Super minor thing that was bugging me when testing the app. If you pressed the big `Play` button on an already running podcast, it'd just run it again. Usually throwing you back a couple seconds. Now it just acts as a toggle.