### PR TITLE
Adding CodeTriage indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Build Status](https://travis-ci.org/SoftwareEngineeringDaily/software-engineering-daily-api.svg?branch=develop)](https://travis-ci.org/SoftwareEngineeringDaily/software-engineering-daily-api)
 [![codecov](https://codecov.io/gh/SoftwareEngineeringDaily/SEDaily-Android/branch/develop/graph/badge.svg)](https://codecov.io/gh/SoftwareEngineeringDaily/SEDaily-Android)
+[![Code Triagers Badge](https://www.codetriage.com/softwareengineeringdaily/sedaily-android/badges/users.svg)](https://www.codetriage.com/softwareengineeringdaily/sedaily-android)
 
 # SEDaily-Android
 


### PR DESCRIPTION
Adding [CodeTriage](https://www.codetriage.com/softwareengineeringdaily/sedaily-android)  indicator to display fellow contributors to the project.